### PR TITLE
Updated initializer config in edit page.

### DIFF
--- a/app/views/applications/edit.html.haml
+++ b/app/views/applications/edit.html.haml
@@ -32,7 +32,7 @@
                 require 'app_perf_rpm'
 
                 AppPerfRpm.configure do |rpm|
-                  rpm.name = "#{@application.name}"
+                  rpm.application_name = "#{@application.name}"
                   rpm.license_key = "#{@application.license_key}"
                 end
 


### PR DESCRIPTION
I found it while using this application, same is mentioned in readme as well.

application name in config should be

> `rpm.application_name = "#{@application.name}" `


  and not 
 

> `rpm.name = "#{@application.name}"`