### PR TITLE
Update ruby version in dockerfile and added git to pull from github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:2.3-alpine
+FROM ruby:2.6.1-alpine
 
-RUN apk update && apk add build-base nodejs postgresql-dev sqlite-dev tzdata curl-dev 
+RUN apk update && apk add build-base nodejs postgresql-dev sqlite-dev tzdata curl-dev git
 
 RUN apk add --no-cache supervisor
 
@@ -17,7 +17,6 @@ COPY .env.docker ./.env.development
 COPY supervisord.conf /etc/supervisord/conf.d/supervisord.conf
 
 LABEL maintainer="Randy Girard <rgirard59@yahoo.com>"
-
 
 CMD cd /app &&\
     bundle exec rake assets:precompile &&\

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 loglevel=debug
 
 [program:app]
-command=bundle exec rails s -p 5000 -b 0.0.0.0 
+command=bundle exec rails s -p 5000 -b 0.0.0.0
 process_name=%(program_name)s_%(process_num)02d
 numprocs=1
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
### Description

* Currently, `docker-compose build` does not run as there is a mismatch for ruby version and `git` is not available to pull the `postgres_ext` gem directly from github
* Updating `ruby` version from `2.3` to `2.6.1` in dockerfile and adding `git` to the apk list will allow the build to complete